### PR TITLE
✨ show if no reactions are found

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -208,6 +208,12 @@ function Reactions() {
       }
     })
 
+  if (all.childElementCount === 0) {
+    const noReactions = document.createElement('div')
+    noReactions.innerText = '🤷‍♂️ no reactions found'
+    all.appendChild(noReactions)
+  }
+
   return all
 }
 


### PR DESCRIPTION
Fixes #16

@wesbos @Hackscore I have updated it to show `🤷‍♂️ no reactions found` (instead of hiding it completely)

The reason for this is that I do my very best to run the script whenever you are on relevant github page (issues/PR/discussions) but I have experienced that sometimes the script is not loaded. That is easy to detect sine the title and credits are missing.  So a page refresh is needed. 

I know that you ask to hide it after the loading spinner, but I'm 🤪 to think that it is broken each time I see a loading spinner and then a complete disappear. If I ever get a setting options for this, then it would make sense to make it optional (hide or message about no finds).