### PR TITLE
add space between emoji and number

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -199,7 +199,7 @@ function Reactions() {
         .forEach((btn) => {
           const { textContent } = btn
           if (textContent?.match(/\d/g)) {
-            reactions += textContent.replace(/\s+/g, '') + ' '
+            reactions += textContent.trim().replace(/\s+/g, ' ') + ' '
           }
         })
       const linkContainer = document.createElement('div')


### PR DESCRIPTION
Minor fix, but it's been bugging me. Adds a space between the count and the emoji. Matching the github style

<img width="86" alt="Screenshot 2023-03-02 at 10 14 20 AM" src="https://user-images.githubusercontent.com/176013/222469213-58656627-d329-4f12-b9d2-0184447d6560.png">
