### PR TITLE
feat: ✨ Add Support for Reactions as Images instead of Emojis

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -185,31 +185,44 @@ function Reactions() {
 
   const issueUrl =
     window.location.origin + window.location.pathname + window.location.search
+
   // Grabbing all reactions Reactions 👍 🚀 🎉 😄 ❤️ 😕 👎 👀
-  const reactions = ['👍', '🚀', '🎉', '😄', '❤️', '😕', '👎', '👀']
+  const reactions = [
+    { emoji: '👍', name: '+1' },
+    { emoji: '🚀', name: 'rocket' },
+    { emoji: '🎉', name: 'tada' },
+    { emoji: '😄', name: 'smile' },
+    { emoji: '❤️', name: 'heart' },
+    { emoji: '😕', name: 'thinking_face' },
+    { emoji: '👎', name: '-1' },
+    { emoji: '👀', name: 'eyes' },
+  ]
+
+  const findReaction = (node: Element) => (reaction: typeof reactions[number]) =>
+    node.textContent?.includes(reaction.emoji) ||
+    node.querySelector(`g-emoji[alias="${reaction.name}"]`)
 
   Array.from(document.querySelectorAll('.js-comment-reactions-options'))
-    .filter((node) =>
-      reactions.some((reaction) => node.textContent?.includes(reaction))
-    )
+    .filter((node) => reactions.some(findReaction(node)))
     .forEach((reactionSection) => {
-      let reactions = ''
-      reactionSection
-        .querySelectorAll('button[class*="reaction"]')
-        .forEach((btn) => {
-          const { textContent } = btn
-          if (textContent?.match(/\d/g)) {
-            reactions += textContent.trim().replace(/\s+/g, ' ') + ' '
-          }
-        })
+      const combinedReactions = Array.from(
+        reactionSection.querySelectorAll('button[class*="reaction"]')
+      )
+        .map((btn) => ({
+          emoji: reactions.find(findReaction(btn))?.emoji,
+          count: btn.textContent?.match(/\d+/)?.join(''),
+        }))
+        .filter((reaction) => reaction.emoji && reaction.count)
+        .reduce((acc, { emoji, count }) => `${acc} ${emoji} ${count}`, '')
+        
       const linkContainer = document.createElement('div')
       linkContainer.classList.add(reactionClass)
 
       const a = document.createElement('a')
-      const linkText = document.createTextNode('  ' + reactions)
+      const linkText = document.createTextNode('  ' + combinedReactions)
       linkContainer.appendChild(a)
       a.appendChild(linkText)
-      a.title = reactions
+      a.title = combinedReactions
 
       let id = null
       while (id == null) {


### PR DESCRIPTION
This fixes #27 by adding an additional check in case the browser does not use emojis but images instead. Tested this on Linux, but would appreciate someone testing this on Mac (assuming that's where GitHub uses emojis) to make sure I didn't break current functionality.