### PR TITLE
Update border color variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -240,7 +240,7 @@ function Reactions() {
 
       linkContainer.style.margin = '0.5rem 0'
       a.href = issueUrl + '#' + id
-      a.style.border = '1px solid var(--color-border-default, #d2dff0)'
+      a.style.border = '1px solid var(--borderColor-default, #d2dff0)'
       a.style.borderRadius = '100px'
       a.style.padding = '2px 7px'
       a.style.color = 'var(--color-fg-muted)'


### PR DESCRIPTION
Github changed their CSS variables, this reflects that. 

Currently:

<img width="288" alt="Screenshot 2024-03-20 at 12 27 24 PM" src="https://github.com/Norfeldt/github-issue-reactions-browser-extension/assets/176013/6f7211aa-c33c-4386-b4ac-18663c36d1ca">

After fix: 

<img width="248" alt="Screenshot 2024-03-20 at 12 28 31 PM" src="https://github.com/Norfeldt/github-issue-reactions-browser-extension/assets/176013/6cb48433-a73b-48c4-a217-ef05452d4316">
