### PR TITLE
🎨 Fix color for discussion votes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -303,7 +303,7 @@ function DiscussionVotes() {
     a.appendChild(linkText)
     a.title = url
     a.href = url
-    a.style.border = '1px solid var(--color-border-default, #d2dff0)'
+    a.style.border = '1px solid var(--borderColor-default, #d2dff0)'
     a.style.borderRadius = '100px'
     a.style.padding = '2px 7px'
     a.style.margin = '0.5rem 0'


### PR DESCRIPTION
Same fix that @wesbos did in #31 but this is to fix discussions ([my comment noticing this](https://github.com/Norfeldt/github-issue-reactions-browser-extension/pull/31#issuecomment-2143969575)).

Before:
<img width="435" alt="image" src="https://github.com/Norfeldt/github-issue-reactions-browser-extension/assets/996134/3484edc4-e6b1-439f-9622-dc01e2573a8d">

After:
<img width="430" alt="image" src="https://github.com/Norfeldt/github-issue-reactions-browser-extension/assets/996134/da9a2cb9-1eb2-487b-80a3-88801229fa38">