### PR TITLE
Extension links back to github

### DIFF
--- a/bundle.ts
+++ b/bundle.ts
@@ -23,6 +23,7 @@ const commonManifest = {
   version,
   description:
     'List a link of reactions on a github issue and pull request page',
+  homepage_url: 'https://github.com/Norfeldt/github-issue-reactions-browser-extension',
   content_scripts: [
     {
       matches: ['*://*.github.com/*'],


### PR DESCRIPTION
I've struggled a few times to find this github.com project, starating from https://chromewebstore.google.com/detail/github-issue-reactions/enekincdenmmbpgkbhflknhaphpajnfd

Supported on both browsers:

- https://developer.chrome.com/docs/extensions/reference/manifest/homepage-url
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/homepage_url